### PR TITLE
Add support for multi-configuration jobs

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
@@ -1,12 +1,12 @@
 package org.jenkinsci.plugins.compressbuildlog;
 
 import hudson.Extension;
-import hudson.model.*;
+import hudson.model.JobProperty;
+import hudson.model.JobPropertyDescriptor;
+import hudson.model.AbstractProject;
+import hudson.model.Job;
+import hudson.model.Run;
 import hudson.model.listeners.RunListener;
-import net.sf.json.JSONObject;
-import org.apache.commons.io.IOUtils;
-import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -15,6 +15,12 @@ import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.GZIPOutputStream;
+
+import net.sf.json.JSONObject;
+
+import org.apache.commons.io.IOUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
 
 public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
 
@@ -28,7 +34,7 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
 
         @Override
         public String getDisplayName() {
-            return "Compress Build Log";
+            return "Compress Build Logs";
         }
 
         @Override
@@ -53,6 +59,27 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
     @Extension
     public final static class CompressBuildlogRunListener extends RunListener<Run> {
 
+        private static boolean hasBuildCompressorConfigured(Run<?, ?> run) {
+            Job<?, ?> parent = run.getParent();
+            
+            // Check project for BuildCompressor configuration
+            if (parent.getProperty(BuildLogCompressor.class) != null) {
+                return true;
+            }
+            
+            // Multi-configuration runs have an extra parent to get to the project. Check that too.
+            if (parent.getParent() instanceof Job) {
+                Job<?, ?> grandParent = (Job<?, ?>)parent.getParent();
+                BuildLogCompressor compressor = grandParent.getProperty(BuildLogCompressor.class);
+                if (null != compressor) {
+                    return true;
+                }
+            }
+
+            // No configuration to be found!
+            return false;
+        }
+        
         @Override
         public void onFinalized(Run run) {
             File log = run.getLogFile();
@@ -62,7 +89,7 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
                 return;
             }
 
-            if (run.getParent().getProperty(BuildLogCompressor.class) == null) {
+            if (!hasBuildCompressorConfigured(run)) {
                 LOGGER.log(Level.FINER, String.format("Skipping %s because the project is not configured to have compressed logs", run));
                 return;
             }

--- a/src/main/resources/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor/config.groovy
+++ b/src/main/resources/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor/config.groovy
@@ -4,6 +4,6 @@ import org.jenkinsci.plugins.compressbuildlog.BuildLogCompressor
 
 def f=namespace(lib.FormTagLib)
 
-f.optionalBlock(title:_("Compress build log"), name:"buildlogcompression",
+f.optionalBlock(title:_("Compress build logs"), name:"buildlogcompression",
         checked:instance!=null, help:"/plugin/compress-buildlog/help.html") {
 }


### PR DESCRIPTION
Added an extra check to get the parent-of-parent of a MatrixRun instance and
perform the same check for the BuildLogCompressor property. This allows the
logs of individual runs of a multi-config job to also be compressed.
