### PR TITLE
Added compression for maven module build logs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532.3</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
+    <version>1.580</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -51,12 +51,12 @@
   </pluginRepositories>
 
   <dependencies>
-        <dependency>
-                <groupId>org.jenkins-ci.main</groupId>
-                <artifactId>maven-plugin</artifactId>
-                <version>[2.0,)</version>
-        </dependency>
-  </dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.main</groupId>
+      <artifactId>maven-plugin</artifactId>
+      <version>[2.0,)</version>
+    </dependency>
+ </dependencies>
 
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
       <groupId>org.jenkins-ci.main</groupId>
       <artifactId>maven-plugin</artifactId>
       <version>[2.0,)</version>
+      <optional>true</optional>
     </dependency>
  </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,4 +50,13 @@
     </pluginRepository>
   </pluginRepositories>
 
+  <dependencies>
+        <dependency>
+                <groupId>org.jenkins-ci.main</groupId>
+                <artifactId>maven-plugin</artifactId>
+                <version>[2.0,)</version>
+        </dependency>
+  </dependencies>
+
+
 </project>

--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
@@ -71,8 +71,8 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
                 // compress module logs, if this is a maven reactor build
                 try {
                     Class<?> c = Class.forName("org.jenkinsci.plugins.compressbuildlog.MavenModuleLogCompressor");
-		    Constructor<?> con = c.getConstructor(Run.class);
-		    ((Runnable)con.newInstance(run)).run();
+                    Constructor<?> con = c.getConstructor(Run.class);
+                    ((Runnable)con.newInstance(run)).run();
 		} catch (Throwable e) {
 		    LOGGER.warning("While creating instance of MavenModuleLogCompressor: "+e);
 		    e.printStackTrace();

--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
@@ -69,19 +69,18 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
             Plugin mvn = Jenkins.getInstance().getPlugin("maven-plugin");
             if (mvn!= null) {
                 // compress module logs, if this is a maven reactor build
-                Class<?> c;
-				try {
-					c = Class.forName("org.jenkinsci.plugins.compressbuildlog.MavenModuleLogCompressor");
-					Constructor<?> con = c.getConstructor(Run.class);
-					((Runnable)con.newInstance(run)).run();
-				} catch (Throwable e) {
-					LOGGER.warning("While creating instance of MavenModuleLogCompressor: "+e);
-					e.printStackTrace();
-				}
+                try {
+                    Class<?> c = Class.forName("org.jenkinsci.plugins.compressbuildlog.MavenModuleLogCompressor");
+		    Constructor<?> con = c.getConstructor(Run.class);
+		    ((Runnable)con.newInstance(run)).run();
+		} catch (Throwable e) {
+		    LOGGER.warning("While creating instance of MavenModuleLogCompressor: "+e);
+		    e.printStackTrace();
+		}
             }
         }
 
-		static final Logger LOGGER = Logger.getLogger(CompressBuildlogRunListener.class.getName());
+        static final Logger LOGGER = Logger.getLogger(CompressBuildlogRunListener.class.getName());
     }
 
 

--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/MavenModuleLogCompressor.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/MavenModuleLogCompressor.java
@@ -1,0 +1,38 @@
+package org.jenkinsci.plugins.compressbuildlog;
+
+import hudson.maven.MavenBuild;
+import hudson.maven.MavenModule;
+import hudson.maven.MavenModuleSetBuild;
+import hudson.model.Run;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class MavenModuleLogCompressor implements Runnable {
+	private Run run;
+
+	public MavenModuleLogCompressor(Run run) {
+		this.run = run;
+	}
+
+	public void run() {
+		if (run instanceof MavenModuleSetBuild) {
+			LOGGER.log(Level.FINE, "Detected MavenModuleSetBuild");
+			MavenModuleSetBuild ms = (MavenModuleSetBuild) run;
+
+			Map<MavenModule, MavenBuild> moduleBuilds = ms
+					.getModuleLastBuilds();
+			for (Entry<MavenModule, MavenBuild> d : moduleBuilds.entrySet()) {
+				if (d != null) {
+					MavenBuild moduleRun = d.getValue();
+					Util.compressLogFile(moduleRun);
+				}
+			}
+		}
+	}
+
+	static final Logger LOGGER = Logger
+			.getLogger(MavenModuleLogCompressor.class.getName());
+}

--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/Util.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/Util.java
@@ -1,0 +1,65 @@
+package org.jenkinsci.plugins.compressbuildlog;
+
+import hudson.model.Run;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.logging.Level;
+import java.util.zip.GZIPOutputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.jenkinsci.plugins.compressbuildlog.BuildLogCompressor.CompressBuildlogRunListener;
+
+public class Util {
+
+	public static void compressLogFile(Run run) {
+	    File log = run.getLogFile();
+	
+	    if (log.getName().endsWith(".gz")) {
+	        // ignore already compressed log
+	        CompressBuildlogRunListener.LOGGER.log(Level.FINER, String.format(
+	                "Skipping %s because the log is already compressed",
+	                run));
+	        return;
+	    }
+	    String gzippedLogName = log.getName() + ".gz";
+	
+	    if (log.getName().equals("log")) {
+	        CompressBuildlogRunListener.LOGGER.log(Level.FINE, String.format("Compressing build log of %s", run));
+	
+	        // regular, expected log file
+	        FileInputStream fis = null;
+	        FileOutputStream fos = null;
+	        GZIPOutputStream gzos = null;
+	
+	        try {
+	            fis = new FileInputStream(log);
+	            fos = new FileOutputStream(new File(log.getParentFile(), gzippedLogName));
+	            gzos = new GZIPOutputStream(fos);
+	            int copiedBytes = IOUtils.copy(fis, gzos);
+	
+	            if (copiedBytes != log.length()) {
+	                CompressBuildlogRunListener.LOGGER.log(Level.WARNING, String.format("Expected to copy %d bytes but copied %d from %s", copiedBytes, log.length(), log.getAbsolutePath()));
+	            }
+	
+	            gzos.finish();
+	            CompressBuildlogRunListener.LOGGER.log(Level.FINE, String.format("Finished compressing build log of %s", run));
+	        } catch (IOException e) {
+	            CompressBuildlogRunListener.LOGGER.log(Level.WARNING, String.format("Failed to compress build log of %s to %s", run, gzippedLogName));
+	            return;
+	        } finally {
+	            IOUtils.closeQuietly(fis);
+	            IOUtils.closeQuietly(fos);
+	            IOUtils.closeQuietly(gzos);
+	        }
+	
+	        // XXX try multiple times because Windows?
+	        if (!log.delete()) {
+	            CompressBuildlogRunListener.LOGGER.log(Level.WARNING, String.format("Failed to delete build log of %s after compression", run));
+	        }
+	    }
+	}
+
+}


### PR DESCRIPTION
We're making massive use of maven reactor builds and compression of the logs reduces the jenkins master's disk usage by about 50%. This however is only true if all the module logs are compressed as well, hence this pull-request.

In order to be able to detect maven-reactor builds, **i added a dependency to maven-plugin**. I guess this is not critical as maven plugin is part of the distribution of jenkins, right?

Please review this change, and let me know if i could change anything.
