### PR TITLE
Pipeline support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
       <version>2.9</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+      <version>1.6</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.532.3</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
+    <version>1.642.3</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>
@@ -49,5 +49,14 @@
       <url>http://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <version>2.9</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,10 @@
   <packaging>hpi</packaging>
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Compress+Build+Log+Plugin</url>
 
+  <properties>
+    <jenkins.version>2.7.4</jenkins.version>
+  </properties>
+
   <licenses>
     <license>
       <name>MIT License</name>

--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
@@ -5,6 +5,7 @@ import hudson.model.*;
 import hudson.model.listeners.RunListener;
 import net.sf.json.JSONObject;
 import org.apache.commons.io.IOUtils;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
@@ -24,6 +25,7 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
     }
 
     @Extension
+    @Symbol("compressBuildLog")
     public final static class DescriptorImpl extends JobPropertyDescriptor {
 
         @Override

--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
@@ -33,7 +33,7 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
 
         @Override
         public boolean isApplicable(Class<? extends Job> jobType) {
-            return AbstractProject.class.isAssignableFrom(jobType);
+            return AbstractProject.class.isAssignableFrom(jobType) || jobType.getName().equals("org.jenkinsci.plugins.workflow.job.WorkflowJob");
         }
 
         @Override

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <!--
   This view is used to render the installed plugins page.
 -->

--- a/src/test/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressorPipelineTest.java
+++ b/src/test/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressorPipelineTest.java
@@ -1,0 +1,25 @@
+import org.jenkinsci.plugins.compressbuildlog.BuildLogCompressor;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.jvnet.hudson.test.JenkinsRule;
+
+public class BuildLogCompressorPipelineTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Test
+    public void testIsApplicable() throws Exception {
+        WorkflowJob workflowJob = r.jenkins.createProject(WorkflowJob.class, "pipeline");
+        Assert.assertNotNull(workflowJob);
+
+        BuildLogCompressor.DescriptorImpl descriptor = new BuildLogCompressor.DescriptorImpl();
+        Assert.assertNotNull(descriptor);
+
+        boolean res = descriptor.isApplicable(workflowJob.getClass());
+        Assert.assertTrue(res);
+    }
+}


### PR DESCRIPTION
Supersedes #3.

Pipeline support is partial as it only compresses the full build log, but not the step specific build logs.