### PR TITLE
Switch order of checks in RunListener

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
+++ b/src/main/java/org/jenkinsci/plugins/compressbuildlog/BuildLogCompressor.java
@@ -82,15 +82,15 @@ public class BuildLogCompressor extends JobProperty<AbstractProject<?, ?>> {
         
         @Override
         public void onFinalized(Run run) {
+            if (!hasBuildCompressorConfigured(run)) {
+                LOGGER.log(Level.FINER, String.format("Skipping %s because the project is not configured to have compressed logs", run));
+                return;
+            }
+
             File log = run.getLogFile();
             if (log.getName().endsWith(".gz")) {
                 // ignore already compressed log
                 LOGGER.log(Level.FINER, String.format("Skipping %s because the log is already compressed", run));
-                return;
-            }
-
-            if (!hasBuildCompressorConfigured(run)) {
-                LOGGER.log(Level.FINER, String.format("Skipping %s because the project is not configured to have compressed logs", run));
                 return;
             }
 


### PR DESCRIPTION
This avoids the WARNING with UnsupportedOperationException when the
listener is called for WorkflowRuns (related to JEP-210).

This probably fixes JENKINS-55004 - Since RunListener.onFinalized is called for every finished Run (even WorkflowRuns) AFAICS, this avoids the JEP-210-related warning on every finished pipeline job...